### PR TITLE
Fix underwear being too slutty in uniforms

### DIFF
--- a/game/major_game_classes/clothing_related/UniformOutfit.rpy
+++ b/game/major_game_classes/clothing_related/UniformOutfit.rpy
@@ -75,7 +75,7 @@ init -2 python:
             elif limited_to_top:
                 return False
 
-            elif self.outfit.get_underwear_slut_score() > slut_limit:
+            elif self.outfit.get_underwear_slut_score() > underwear_limit:
                 return False
 
             elif not self.outfit.is_suitable_underwear_set():


### PR DESCRIPTION
Use `underwear_limit` instead of `slut_limit` to make sure slutty underwear can't be mandated without proper policy.