### PR TITLE
Allow "Skip the foreplay" to lead to public sex

### DIFF
--- a/game/general_actions/interaction_actions/grope_descriptions.rpy
+++ b/game/general_actions/interaction_actions/grope_descriptions.rpy
@@ -83,7 +83,7 @@ label grope_waist(the_person):
 
         menu:
             "Skip the foreplay":
-                call fuck_person(the_person) from _call_fuck_person
+                call fuck_person(the_person, private = mc.location.get_person_count() <= 1) from _call_fuck_person
                 $ the_person.call_dialogue("sex_review", the_report = _return)
                 $ the_person.review_outfit()
                 return False


### PR DESCRIPTION
The gropee "wants to fuck right away," and it would take at least 2 minutes to find a dark ally or unused closet. However, the primary purpose is allowing public sex with high-slut, low-love, low-obedience people, which is currently impossible.